### PR TITLE
Explicitly check that otp_attempt param is not nil in order to avoid 'RO...

### DIFF
--- a/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
@@ -8,8 +8,7 @@ module Devise
         # 1. The password and the OTP are correct
         # 2. The password is correct, and OTP is not required for login
         # We check the OTP, then defer to DatabaseAuthenticatable
-        if validate(resource) { !resource.otp_required_for_login ||
-                                resource.valid_otp?(params[scope]['otp_attempt']) }
+        if validate(resource) { validate_otp(resource) }
           super
         end
 
@@ -18,6 +17,12 @@ module Devise
         # We want to cascade to the next strategy if this one fails,
         # but database authenticatable automatically halts on a bad password
         @halted = false if @result == :failure
+      end
+
+      def validate_otp(resource)
+        return true unless resource.otp_required_for_login
+        return if params[scope]['otp_attempt'].nil?
+        resource.valid_otp?(params[scope]['otp_attempt'])
       end
     end
   end


### PR DESCRIPTION
imho the gem should explicitly check that otp_attempt param is not nil before calling
`resource.valid_otp?(params[scope]['otp_attempt'])`
otherwise an `ArgumentError Exception: ROTP only verifies strings` might be raised.

This happens for example when email and password params are set but not otp_attempt, in this case I would expect that current_user is nil and not that it raises an exception.

I would have added tests but I have not found any existing controller spec