### PR TITLE
Upgrade to rspec 3

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'bundler',    '> 1.0'
-  s.add_development_dependency 'rspec',      '> 2', '< 3'
+  s.add_development_dependency 'rspec',      '> 3'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'faker'
   s.add_development_dependency 'timecop'

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -5,25 +5,25 @@ shared_examples 'two_factor_authenticatable' do
 
   describe 'required_fields' do
     it 'should have the attr_encrypted fields for otp_secret' do
-      Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class).should =~ ([:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt])
+      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt)
     end
   end
 
   describe '#otp_secret' do
     it 'should be of the configured length' do
-      subject.otp_secret.length.should eq(subject.class.otp_secret_length)
+      expect(subject.otp_secret.length).to eq(subject.class.otp_secret_length)
     end
 
     it 'stores the encrypted otp_secret' do
-      subject.encrypted_otp_secret.should_not be_nil
+      expect(subject.encrypted_otp_secret).to_not be_nil
     end
 
     it 'stores an iv for otp_secret' do
-      subject.encrypted_otp_secret_iv.should_not be_nil
+      expect(subject.encrypted_otp_secret_iv).to_not be_nil
     end
 
     it 'stores a salt for otp_secret' do
-      subject.encrypted_otp_secret_salt.should_not be_nil
+      expect(subject.encrypted_otp_secret_salt).to_not be_nil
     end
   end
 
@@ -41,22 +41,22 @@ shared_examples 'two_factor_authenticatable' do
 
     it 'validates a precisely correct OTP' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now)
-      subject.valid_otp?(otp).should be true
+      expect(subject.valid_otp?(otp)).to be true
     end
 
     it 'validates an OTP within the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift, true)
-      subject.valid_otp?(otp).should be true
+      expect(subject.valid_otp?(otp)).to be true
     end
 
     it 'does not validate an OTP above the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift * 2, true)
-      subject.valid_otp?(otp).should be false
+      expect(subject.valid_otp?(otp)).to be false
     end
 
     it 'does not validate an OTP below the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now - subject.class.otp_allowed_drift * 2, true)
-      subject.valid_otp?(otp).should be false
+      expect(subject.valid_otp?(otp)).to be false
     end
   end
 
@@ -66,11 +66,11 @@ shared_examples 'two_factor_authenticatable' do
     let(:issuer)            { "Tinfoil" }
 
     it "should return uri with specified account" do
-      subject.otp_provisioning_uri(account).should match(%r{otpauth://totp/#{account}\?secret=\w{#{otp_secret_length}}})
+      expect(subject.otp_provisioning_uri(account)).to match(%r{otpauth://totp/#{account}\?secret=\w{#{otp_secret_length}}})
     end
 
     it 'should return uri with issuer option' do
-      subject.otp_provisioning_uri(account, issuer: issuer).should match(%r{otpauth://totp/#{account}\?secret=\w{#{otp_secret_length}}&issuer=#{issuer}$})
+      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{account}\?secret=\w{#{otp_secret_length}}&issuer=#{issuer}$})
     end
   end
 end

--- a/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
@@ -1,7 +1,7 @@
 shared_examples 'two_factor_backupable' do
   describe 'required_fields' do
     it 'has the attr_encrypted fields for otp_backup_codes' do
-      Devise::Models::TwoFactorBackupable.required_fields(subject.class).should =~ [:otp_backup_codes]
+      expect(Devise::Models::TwoFactorBackupable.required_fields(subject.class)).to contain_exactly(:otp_backup_codes)
     end
   end
 
@@ -12,24 +12,23 @@ shared_examples 'two_factor_backupable' do
       end
 
       it 'generates the correct number of new recovery codes' do
-        subject.otp_backup_codes.length.should
-          eq(subject.class.otp_number_of_backup_codes)
+        expect(subject.otp_backup_codes.length).to eq(subject.class.otp_number_of_backup_codes)
       end
 
       it 'generates recovery codes of the correct length' do
         @plaintext_codes.each do |code|
-          code.length.should eq(subject.class.otp_backup_code_length)
+          expect(code.length).to eq(subject.class.otp_backup_code_length)
         end
       end
 
       it 'generates distinct recovery codes' do
-        @plaintext_codes.uniq.should =~ @plaintext_codes
+        expect(@plaintext_codes.uniq).to contain_exactly(*@plaintext_codes)
       end
 
       it 'stores the codes as BCrypt hashes' do
         subject.otp_backup_codes.each do |code|
           # $algorithm$cost$(22 character salt + 31 character hash)
-          code.should =~ /\A\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}\z/
+          expect(code).to match(/\A\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}\z/)
         end
       end
     end
@@ -44,7 +43,7 @@ shared_examples 'two_factor_backupable' do
       end
 
       it 'invalidates the existing recovery codes' do
-        (subject.otp_backup_codes & old_codes_hashed).should =~ []
+        expect((subject.otp_backup_codes & old_codes_hashed)).to match []
       end
     end
   end
@@ -56,14 +55,14 @@ shared_examples 'two_factor_backupable' do
 
     context 'given an invalid recovery code' do
       it 'returns false' do
-        subject.invalidate_otp_backup_code!('password').should be false
+        expect(subject.invalidate_otp_backup_code!('password')).to be false
       end
     end
 
     context 'given a valid recovery code' do
       it 'returns true' do
         @plaintext_codes.each do |code|
-          subject.invalidate_otp_backup_code!(code).should be true
+          expect(subject.invalidate_otp_backup_code!(code)).to be true
         end
       end
 
@@ -71,7 +70,7 @@ shared_examples 'two_factor_backupable' do
         code = @plaintext_codes.sample
 
         subject.invalidate_otp_backup_code!(code)
-        subject.invalidate_otp_backup_code!(code).should be false
+        expect(subject.invalidate_otp_backup_code!(code)).to be false
       end
 
       it 'does not invalidate the other recovery codes' do
@@ -81,7 +80,7 @@ shared_examples 'two_factor_backupable' do
         @plaintext_codes.delete(code)
 
         @plaintext_codes.each do |code|
-          subject.invalidate_otp_backup_code!(code).should be true
+          expect(subject.invalidate_otp_backup_code!(code)).to be true
         end
       end
     end


### PR DESCRIPTION
First off, thanks for maintaining this gem. We're using the shared examples in a project with rspec 3.2. This results in a deprecation warning. I realize this change would be breaking for anyone still using rspec 2.x, but I thought I'd put it out there.