### PR TITLE
Disallow subsequent OTPs once validated via timesteps

### DIFF
--- a/demo/db/migrate/20140516191259_add_devise_two_factor_to_users.rb
+++ b/demo/db/migrate/20140516191259_add_devise_two_factor_to_users.rb
@@ -3,6 +3,7 @@ class AddDeviseTwoFactorToUsers < ActiveRecord::Migration
     add_column :users, :encrypted_otp_secret, :string
     add_column :users, :encrypted_otp_secret_iv, :string
     add_column :users, :encrypted_otp_secret_salt, :string
+    add_column :users, :consumed_timestep, :integer
     add_column :users, :otp_required_for_login, :boolean
   end
 end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20140516191259) do
     t.string   "encrypted_otp_secret"
     t.string   "encrypted_otp_secret_iv"
     t.string   "encrypted_otp_secret_salt"
+    t.integer  "consumed_timestep"
     t.boolean  "otp_required_for_login"
   end
 

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -27,7 +27,7 @@ shared_examples 'two_factor_authenticatable' do
     end
   end
 
-  describe '#valid_otp?' do
+  describe '#validate_and_consume_otp!' do
     let(:otp_secret) { '2z6hxkdwi3uvrnpn' }
 
     before :each do
@@ -41,36 +41,36 @@ shared_examples 'two_factor_authenticatable' do
 
     it 'validates a precisely correct OTP' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now)
-      expect(subject.valid_otp?(otp)).to be true
+      expect(subject.validate_and_consume_otp!(otp)).to be true
     end
 
     it 'does not validate a previously precisely correct OTP' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now)
-      expect(subject.valid_otp?(otp)).to be true
-      expect(subject.valid_otp?(otp)).to be false
-      expect(subject.valid_otp?(otp)).to be false
+      expect(subject.validate_and_consume_otp!(otp)).to be true
+      expect(subject.validate_and_consume_otp!(otp)).to be false
+      expect(subject.validate_and_consume_otp!(otp)).to be false
     end
 
     it 'validates an OTP within the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift, true)
-      expect(subject.valid_otp?(otp)).to be true
+      expect(subject.validate_and_consume_otp!(otp)).to be true
     end
 
     it 'does not validate a previously valid OTP within the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift, true)
-      expect(subject.valid_otp?(otp)).to be true
-      expect(subject.valid_otp?(otp)).to be false
-      expect(subject.valid_otp?(otp)).to be false
+      expect(subject.validate_and_consume_otp!(otp)).to be true
+      expect(subject.validate_and_consume_otp!(otp)).to be false
+      expect(subject.validate_and_consume_otp!(otp)).to be false
     end
 
     it 'does not validate an OTP above the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift * 2, true)
-      expect(subject.valid_otp?(otp)).to be false
+      expect(subject.validate_and_consume_otp!(otp)).to be false
     end
 
     it 'does not validate an OTP below the allowed drift' do
       otp = ROTP::TOTP.new(otp_secret).at(Time.now - subject.class.otp_allowed_drift * 2, true)
-      expect(subject.valid_otp?(otp)).to be false
+      expect(subject.validate_and_consume_otp!(otp)).to be false
     end
   end
 

--- a/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
@@ -22,7 +22,7 @@ module Devise
       def validate_otp(resource)
         return true unless resource.otp_required_for_login
         return if params[scope]['otp_attempt'].nil?
-        resource.valid_otp?(params[scope]['otp_attempt'])
+        resource.validate_and_consume_otp!(params[scope]['otp_attempt'])
       end
     end
   end

--- a/lib/generators/devise_two_factor/devise_two_factor_generator.rb
+++ b/lib/generators/devise_two_factor/devise_two_factor_generator.rb
@@ -22,6 +22,7 @@ module DeviseTwoFactor
                                 "encrypted_otp_secret:string",
                                 "encrypted_otp_secret_iv:string",
                                 "encrypted_otp_secret_salt:string",
+                                "consumed_timestep:integer",
                                 "otp_required_for_login:boolean"
                               ]
 

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -10,7 +10,8 @@ class TwoFactorAuthenticatableDouble
   attr_accessor :consumed_timestep
 
   def save(validate)
-    # noop
+    # noop for testing
+    true
   end
 end
 

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -6,6 +6,12 @@ class TwoFactorAuthenticatableDouble
   extend  ::Devise::Models
 
   devise :two_factor_authenticatable, :otp_secret_encryption_key => 'test-key'
+
+  attr_accessor :consumed_timestep
+
+  def save(validate)
+    # noop
+  end
 end
 
 describe ::Devise::Models::TwoFactorAuthenticatable do


### PR DESCRIPTION
In order to be fully RFC 6238 compliant for TOTPs, no valid OTP may be used more than once for a given timestep. By storing the timestep of the last successfully validated OTP, we achieve this desired behaviour.

TOTP#timecode is a private method, so we had to duplicate it in order to obtain the current server timestep. Thankfully it's simply time divided by interval.

I was having issues with using `resource.save!` in the strategy class as a means of object persistence to the database. Ultimately, I opted to use the ActiveRecord `save()` method inside the devise model which is what Devise does in its own model definitions.

Burning the timestep bumps the `updated_at` value for the model. Not sure if this is a feature or bug.

Shitty .gif of it working in the demo app:
![burned-otps](https://cloud.githubusercontent.com/assets/740289/9697650/233f1950-5363-11e5-889a-ccf6a000173d.gif)

Refs #30