### PR TITLE
Inform user to use :text for backup migration if MySQL dbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The final installation step is dependent on your version of Rails. If you're not
 ```ruby
 class AddDeviseTwoFactorBackupableToUsers < ActiveRecord::Migration
   def change
+    # Change type from :string to :text if using MySQL database
     add_column :users, :otp_backup_codes, :string, array: true
   end
 end
@@ -181,6 +182,7 @@ You'll then simply have to create a migration to add an array named `otp_backup_
 ```ruby
 class AddTwoFactorBackupCodesToUsers < ActiveRecord::Migration
   def change
+    # Change type from :string_array to :text_array if using MySQL database
     add_column :users, :otp_backup_codes, :string_array
   end
 end


### PR DESCRIPTION
I got bit by this.

Not sure if there is a handy way for the migration to check which db adapter is being used and automatically determining the type. Maybe leave it up to the user to choose.

Also not entirely sure if `text_array` is a thing, but a cursory skim of https://github.com/tlconnor/activerecord-postgres-array shows it supports it.

See #18.