### PR TITLE
Deserialize YAML array of backup codes if detected

### DIFF
--- a/lib/devise_two_factor/models/two_factor_backupable.rb
+++ b/lib/devise_two_factor/models/two_factor_backupable.rb
@@ -33,6 +33,7 @@ module Devise
       # iff that code is a valid backup code.
       def invalidate_otp_backup_code!(code)
         codes = self.otp_backup_codes || []
+        codes = YAML.load codes unless codes.is_a? Array # Support MySQL storage
 
         codes.each do |backup_code|
           next unless Devise::Encryptor.compare(self.class, backup_code, code)

--- a/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
@@ -57,6 +57,11 @@ shared_examples 'two_factor_backupable' do
       it 'returns false' do
         expect(subject.invalidate_otp_backup_code!('password')).to be false
       end
+
+      it 'gracefully handles when MySQL doesn\'t deserialize YAML from database' do
+        subject.otp_backup_codes = subject.otp_backup_codes.to_yaml
+        expect(subject.invalidate_otp_backup_code!('password')).to be false
+      end
     end
 
     context 'given a valid recovery code' do
@@ -79,6 +84,13 @@ shared_examples 'two_factor_backupable' do
 
         @plaintext_codes.delete(code)
 
+        @plaintext_codes.each do |code|
+          expect(subject.invalidate_otp_backup_code!(code)).to be true
+        end
+      end
+
+      it 'gracefully handles when MySQL doesn\'t deserialize YAML from database' do
+        subject.otp_backup_codes = subject.otp_backup_codes.to_yaml
         @plaintext_codes.each do |code|
           expect(subject.invalidate_otp_backup_code!(code)).to be true
         end


### PR DESCRIPTION
When using MySQL in Rails 4.0, it appears the array in the text column is not deserialized and `otp_backup_codes` returns a String instead of Array.

I personally encountered this, not sure what's at fault. That is, is it a Rails 4.0 bug? Expected behaviour? A result of `:text` vs `:string`? etc etc.