### PR TITLE
Allow Devise 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
+
 cache: bundler
+
 rvm:
-  - "1.9.3"
-  - "2.0.0"
-  - "2.1"
-  - "2.2"
-  - jruby-19mode # JRuby in 1.9 mode
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ def configure_permitted_parameters
 end
 ```
 
+If you're running Devise 4.0.0 or above, you'll want to use `.permit` instead:
+
+```ruby
+before_action :configure_permitted_parameters, if: :devise_controller?
+
+...
+
+protected
+
+def configure_permitted_parameters
+  devise_parameter_sanitizer.permit(:sign_in, keys: [:otp_attempt])
+end
+```
+
 **After running the generator, verify that :database_authenticatable is not being loaded by your model. The generator will try to remove it, but if you have a non-standard Devise setup, this step may fail. Loading both :database_authenticatable and `:two_factor_authenticatable` in a model will allow users to bypass two-factor authenticatable due to the way Warden handles cascading strategies.**
 
 ## Designing Your Workflow

--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -24,10 +24,12 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
+  s.required_ruby_version = '>= 2.1.0'
+
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'activesupport'
-  s.add_runtime_dependency 'attr_encrypted', '~> 1.3.2'
-  s.add_runtime_dependency 'devise',         '~> 3.5.0'
+  s.add_runtime_dependency 'attr_encrypted', '~> 1.4.0'
+  s.add_runtime_dependency 'devise',         '~> 4.0.0.rc2'
   s.add_runtime_dependency 'rotp',           '~> 2'
 
   s.add_development_dependency 'activemodel'

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 require 'active_model'
 
 class TwoFactorAuthenticatableDouble
+  extend ::ActiveModel::Callbacks
+  extend AttrEncrypted
   include ::ActiveModel::Validations::Callbacks
   extend  ::Devise::Models
+
+  define_model_callbacks :update
 
   devise :two_factor_authenticatable, :otp_secret_encryption_key => 'test-key'
 

--- a/spec/devise/models/two_factor_backupable_spec.rb
+++ b/spec/devise/models/two_factor_backupable_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 class TwoFactorBackupableDouble
+  extend ::ActiveModel::Callbacks
   include ::ActiveModel::Validations::Callbacks
+  extend AttrEncrypted
   extend  ::Devise::Models
+
+  define_model_callbacks :update
 
   devise :two_factor_authenticatable, :two_factor_backupable,
          :otp_secret_encryption_key => 'test-key'


### PR DESCRIPTION
This PR includes the following changes:
- Allow Devise `>= 3.5.0 `.
- Update the README to include `devise_parameter_sanitizer` syntax for Devise 4.0.0, see the [4.0.0 Changelog](https://github.com/plataformatec/devise/blob/master/CHANGELOG.md#400rc1---2016-01-02) for the specific changes.

This resolves #58.

I've tested this with Devise 4.0.0.rc2 on our Rails 5 branch for ImageHex, and there are some deprecation warnings, but everything works just fine. :+1: