### PR TITLE
Use 128 bits, not 1024, as a secret key length

### DIFF
--- a/lib/devise-two-factor.rb
+++ b/lib/devise-two-factor.rb
@@ -5,7 +5,7 @@ require 'devise_two_factor/strategies'
 module Devise
   # The length of generated OTP secrets
   mattr_accessor :otp_secret_length
-  @@otp_secret_length = 128
+  @@otp_secret_length = 24
 
   # The number of seconds before and after the current
   # time for which codes will be accepted


### PR DESCRIPTION
`ROTP::Base32.random_base32` accepts a length in bytes, not bits, as a parameter. `otp_secret_length` seems to be mistakenly set to 128 bytes, rather than 128 bits, by default.

While 1024 bits results in a more secure key, it is impossible for users who are unable to scan a QR code to enter it into Google Authenticator.

RFC 4226 recommends a minimum of 128 bits: https://tools.ietf.org/html/rfc4226.html#section-4.