### PR TITLE
Update the devise version requirement to `~> 4.0`

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4'
-  s.add_runtime_dependency 'devise',         '~> 4.0.0.rc2'
+  s.add_runtime_dependency 'devise',         '~> 4.0'
   s.add_runtime_dependency 'rotp',           '~> 2.0'
 
   s.add_development_dependency 'activemodel'


### PR DESCRIPTION
This allows 4.0.0, 4.1.0, etc. Previous version requirement was causing issues with my testing.