### PR TITLE
Use preferred attr_encrypted mode :per_attribute_iv

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ This generator will add a few columns to the specified model:
 
 * encrypted_otp_secret
 * encrypted_otp_secret_iv
-* encrypted_otp_secret_salt
 * consumed_timestep
 * otp_required_for_login
 

--- a/demo/db/migrate/20140516191259_add_devise_two_factor_to_users.rb
+++ b/demo/db/migrate/20140516191259_add_devise_two_factor_to_users.rb
@@ -2,7 +2,6 @@ class AddDeviseTwoFactorToUsers < ActiveRecord::Migration
   def change
     add_column :users, :encrypted_otp_secret, :string
     add_column :users, :encrypted_otp_secret_iv, :string
-    add_column :users, :encrypted_otp_secret_salt, :string
     add_column :users, :consumed_timestep, :integer
     add_column :users, :otp_required_for_login, :boolean
   end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 20140516191259) do
     t.datetime "updated_at"
     t.string   "encrypted_otp_secret"
     t.string   "encrypted_otp_secret_iv"
-    t.string   "encrypted_otp_secret_salt"
     t.integer  "consumed_timestep"
     t.boolean  "otp_required_for_login"
   end

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -15,14 +15,14 @@ module Devise
         unless attr_encrypted?(:otp_secret)
           attr_encrypted :otp_secret,
             :key  => self.otp_secret_encryption_key,
-            :mode => :per_attribute_iv_and_salt unless self.attr_encrypted?(:otp_secret)
+            :mode => :per_attribute_iv unless self.attr_encrypted?(:otp_secret)
         end
 
         attr_accessor :otp_attempt
       end
 
       def self.required_fields(klass)
-        [:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt, :consumed_timestep]
+        [:encrypted_otp_secret, :encrypted_otp_secret_iv, :consumed_timestep]
       end
 
       # This defaults to the model's otp_secret

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -6,7 +6,7 @@ shared_examples 'two_factor_authenticatable' do
 
   describe 'required_fields' do
     it 'should have the attr_encrypted fields for otp_secret' do
-      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt, :consumed_timestep)
+      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:encrypted_otp_secret, :encrypted_otp_secret_iv, :consumed_timestep)
     end
   end
 
@@ -21,10 +21,6 @@ shared_examples 'two_factor_authenticatable' do
 
     it 'stores an iv for otp_secret' do
       expect(subject.encrypted_otp_secret_iv).to_not be_nil
-    end
-
-    it 'stores a salt for otp_secret' do
-      expect(subject.encrypted_otp_secret_salt).to_not be_nil
     end
   end
 

--- a/lib/generators/devise_two_factor/devise_two_factor_generator.rb
+++ b/lib/generators/devise_two_factor/devise_two_factor_generator.rb
@@ -21,7 +21,6 @@ module DeviseTwoFactor
                                 "add_devise_two_factor_to_#{plural_name}",
                                 "encrypted_otp_secret:string",
                                 "encrypted_otp_secret_iv:string",
-                                "encrypted_otp_secret_salt:string",
                                 "consumed_timestep:integer",
                                 "otp_required_for_login:boolean"
                               ]


### PR DESCRIPTION
Mode :per_attribute_iv_and_salt is deprecated and will be removed in the next major attr_encrypted release.

See https://github.com/attr-encrypted/attr_encrypted/issues/205