### PR TITLE
Qualify call to rspec shared_examples

### DIFF
--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples 'two_factor_authenticatable' do
+RSpec.shared_examples 'two_factor_authenticatable' do
   before :each do
     subject.otp_secret = subject.class.generate_otp_secret
     subject.consumed_timestep = nil

--- a/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples 'two_factor_backupable' do
+RSpec.shared_examples 'two_factor_backupable' do
   describe 'required_fields' do
     it 'has the attr_encrypted fields for otp_backup_codes' do
       expect(Devise::Models::TwoFactorBackupable.required_fields(subject.class)).to contain_exactly(:otp_backup_codes)


### PR DESCRIPTION
`require 'devise_two_factor/spec_helpers'` fails for some rails apps, due to `RSpec` not being qualified for calls to `shared_examples`

namely any app that has `config.disable_monkey_patching!` in rspec config.