### PR TITLE
Skips extra validate when otp attempt looks like its coming from Auth…

### DIFF
--- a/lib/devise_two_factor/strategies/two_factor_backupable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_backupable.rb
@@ -2,6 +2,12 @@ module Devise
   module Strategies
     class TwoFactorBackupable < Devise::Strategies::DatabaseAuthenticatable
 
+      def validate(resource)
+        if params[scope]['otp_attempt'] && resembles_backup_code?(params[scope]['otp_attempt'])
+          super(resource) { yield }
+        end
+      end
+
       def authenticate!
         resource = mapping.to.find_for_database_authentication(authentication_hash)
 
@@ -18,6 +24,13 @@ module Devise
         # but database authenticatable automatically halts on a bad password
         @halted = false if @result == :failure
       end
+
+      private
+
+      def resembles_backup_code?(otp_attempt)
+        otp_attempt.length > 6
+      end
+
     end
   end
 end

--- a/spec/strategies/two_factor_backupable_spec.rb
+++ b/spec/strategies/two_factor_backupable_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'active_model'
+
+class TwoFactorBackupableDouble
+  extend ::ActiveModel::Callbacks
+  include ::ActiveModel::Validations::Callbacks
+  extend  ::Devise::Models
+
+  define_model_callbacks :update
+
+  devise :two_factor_authenticatable, :two_factor_backupable,
+         :otp_secret_encryption_key => 'test-key'*4
+
+  attr_accessor :otp_backup_codes
+end
+
+describe Devise::Strategies::TwoFactorBackupable do
+
+  let(:strategy){ Devise::Strategies::TwoFactorBackupable }
+  let(:resource) { TwoFactorBackupableDouble.new }
+
+  subject{ strategy.new(env_with_params('/', { user: { otp_attempt: '123456' } } ), 'user') }
+
+  it 'No OTP attempt (Normal login)' do
+    subject = strategy.new(env_with_params('/', { user: { otp_attempt: nil } } ), 'user')
+    allow(subject).to receive_message_chain(:mapping, :to, :find_for_database_authentication) { resource }
+
+    subject._run!
+    expect(subject.result).to be_nil
+  end
+
+  it 'OTP attempt with 6 digits (Google Authenticator)' do
+    allow(subject).to receive_message_chain(:mapping, :to, :find_for_database_authentication) { resource }
+
+    subject._run!
+    expect(subject.result).to be_nil
+  end
+
+  it 'OTP attempt with 7 digits (Backup code)' do
+    subject = strategy.new(env_with_params('/', { user: { otp_attempt: '1234567' } } ), 'user')
+    allow(resource).to receive(:invalidate_otp_backup_code!).and_return(true)
+    allow(resource).to receive(:save!).and_return(true)
+    allow(subject).to receive_message_chain(:mapping, :to, :find_for_database_authentication) { resource }
+
+    subject._run!
+    expect(subject.result).to eql :failure
+  end
+
+  def env_with_params(path = "/", params = {}, env = {})
+    method = params.delete(:method) || "GET"
+    env = { 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => "#{method}" }.merge(env)
+    Rack::MockRequest.env_for("#{path}?#{Rack::Utils.build_nested_query(params)}", env)
+  end
+end


### PR DESCRIPTION
#127

Assuming you have a Devise setup like this:

```
class User < ApplicationRecord
  devise :two_factor_authenticatable, :two_factor_backupable, otp_number_of_backup_codes: 10,
         otp_backup_code_length: 6, :otp_secret_encryption_key => ENV['OPT_KEY']

  devise :registerable, :recoverable, :rememberable, :trackable,
         :validatable, :confirmable, :lockable
```

With a configuration like this:

```
  config.warden do |manager|
    manager.default_strategies(:scope => :user).delete(:two_factor_authenticatable)
    manager.default_strategies(:scope => :user).delete(:two_factor_backupable)
    manager.default_strategies(:scope => :user).unshift :two_factor_authenticatable
    manager.default_strategies(:scope => :user).unshift :two_factor_backupable
  end
```

`failed_attempts` gets called every time `validate` runs in the cascading strategies.

Assuming you enforce `two_factor_backupable` strategy first, you can reduce the `failed_attempts` to not increment twice in the following cases:
- Normal login with invalid password
- OTP enabled, invalid OTP entered less than 7 characters

Unfortunately, it will still increment twice when:
- OTP enabled, invalid OTP entered 7 digits or more
