### PR TITLE
Remove duplicate regist stratery

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ Rails.application.config.filter_parameters += [:otp_attempt]
 ## Backup Codes
 Devise-Two-Factor is designed with extensibility in mind. One such extension, `TwoFactorBackupable`, is included and serves as a good example of how to extend this gem. This plugin allows you to add the ability to generate single-use backup codes for a user, which they may use to bypass two-factor authentication, in the event that they lose access to their device.
 
-To install it, you need to add the `:two_factor_backupable` directive to your model.
+To install it, you either add the `:two_factor_backupable` directive to your model
 
 ```ruby
 devise :two_factor_backupable
 ```
 
-You'll also be required to enable the `:two_factor_backupable` strategy, by adding the following line to your Warden config in your Devise initializer, substituting :user for the name of your Devise scope.
+or by adding the following line to your Warden config in your Devise initializer, substituting :user for the name of your Devise scope.
 
 ```ruby
 manager.default_strategies(:scope => :user).unshift :two_factor_backupable

--- a/lib/generators/devise_two_factor/devise_two_factor_generator.rb
+++ b/lib/generators/devise_two_factor/devise_two_factor_generator.rb
@@ -10,7 +10,6 @@ module DeviseTwoFactor
 
       def install_devise_two_factor
         create_devise_two_factor_migration
-        inject_strategies_into_warden_config
         inject_devise_directives_into_model
       end
 
@@ -27,16 +26,6 @@ module DeviseTwoFactor
                               ]
 
         Rails::Generators.invoke('active_record:migration', migration_arguments)
-      end
-
-      def inject_strategies_into_warden_config
-        config_path = File.join('config', 'initializers', 'devise.rb')
-
-        content = "  config.warden do |manager|\n" \
-                  "    manager.default_strategies(:scope => :#{singular_table_name}).unshift :two_factor_authenticatable\n" \
-                  "  end\n\n"
-
-        inject_into_file(config_path, content, after: "Devise.setup do |config|\n")
       end
 
       def inject_devise_directives_into_model


### PR DESCRIPTION
I'm working on an app use `two_factor_backupable` of `devise-two-factor`. It really helpful, thank for that!

I detected there are two problems may need to be fixed.
## Problem 01:  Remove duplicate of register`two_factor_authenticatable` strategy.
The gem registers `two_factor_authenticatable` strategy on generations.
+ The first one is add `two_factor_authenticatable` into model.
+ The second one is inject strategy into warden config.
<img width="1175" alt="screen shot 2018-08-28 at 1 03 07 am" src="https://user-images.githubusercontent.com/12691828/44677025-1a05c180-aa5f-11e8-943e-2c943bd19deb.png">

## Problem 02:  It happens again with `two_factor_backupable` in another way.
The installation instruction of `two_factor_backupable` in [README.md file](https://github.com/tinfoil/devise-two-factor/blob/master/README.md#backup-codes) requires to add `two_factor_backupable` to both model and Devise initializer.

Checking on `waden`, it is duplicated.

<img width="1156" alt="screen shot 2018-08-27 at 5 04 35 pm" src="https://user-images.githubusercontent.com/12691828/44654758-f6ba2280-aa1c-11e8-9264-5f96d8372744.png">
So I think the requirement to add `:two_factor_backupable` into devise initializer is redundant.

#
Ruby version: `ruby 2.5.1p57`
Rails version: `Rails 5.2.0`