### PR TITLE
Fix paranoid-mode being ignored

### DIFF
--- a/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
@@ -12,7 +12,7 @@ module Devise
           super
         end
 
-        fail(:not_found_in_database) unless resource
+        fail(Devise.paranoid ? :invalid : :not_found_in_database) unless resource
 
         # We want to cascade to the next strategy if this one fails,
         # but database authenticatable automatically halts on a bad password


### PR DESCRIPTION
Devise's paranoid-mode is meant to hide when a record with an e-mail exists in the system, by always showing the invalid error message instead of conditionally revealing when a record is not found. This gem ignores the setting and reveals existing accounts during an enumeration attack.