### PR TITLE
validate an OTP on model level and add to errors

### DIFF
--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -19,7 +19,7 @@ module Devise
         end
 
         attr_accessor :otp_attempt
-        validate :validate_otp, if: ->{ otp_attempt.present?}
+        validate :validate_otp, if: ->{ otp_attempt.present? && otp_required_for_login }
 
       end
 
@@ -89,7 +89,7 @@ module Devise
       def validate_otp
         self.errors.add(:otp_attempt, :invalid) unless validate_and_consume_otp!(otp_attempt)
       end
-      
+
     end
   end
 end

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -19,6 +19,8 @@ module Devise
         end
 
         attr_accessor :otp_attempt
+        validate :validate_otp, if: ->{ otp_attempt.present?}
+
       end
 
       def self.required_fields(klass)
@@ -81,6 +83,13 @@ module Devise
           ROTP::Base32.random_base32(otp_secret_length)
         end
       end
+
+      private
+
+      def validate_otp
+        self.errors.add(:otp_attempt, :invalid) unless validate_and_consume_otp!(otp_attempt)
+      end
+      
     end
   end
 end

--- a/lib/devise_two_factor/version.rb
+++ b/lib/devise_two_factor/version.rb
@@ -1,3 +1,3 @@
 module DeviseTwoFactor
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
Ability to validate a given OTP on model level for secure operations

```
u = User.first
u.update(special_feature: true, otp_attempt: "wrong_OTP")
u.errors
# => @messages={:otp_attempt=>["is invalid"]}>

u.otp_attempt = "788200"
u.save
# => true
```