### PR TITLE
Don't require attr encrypted gem if otp_secret attr is already present

### DIFF
--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -7,7 +7,7 @@ module Devise
       include Devise::Models::DatabaseAuthenticatable
 
       included do
-        unless %i[otp_secret otp_secret=].all? { |attr| respond_to?(attr) }
+        unless %i[otp_secret otp_secret=].all? { |attr| method_defined?(attr) }
           require 'attr_encrypted'
 
           unless singleton_class.ancestors.include?(AttrEncrypted)

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -1,4 +1,3 @@
-require 'attr_encrypted'
 require 'rotp'
 
 module Devise
@@ -8,14 +7,18 @@ module Devise
       include Devise::Models::DatabaseAuthenticatable
 
       included do
-        unless singleton_class.ancestors.include?(AttrEncrypted)
-          extend AttrEncrypted
-        end
+        unless %i[otp_secret otp_secret=].all? { |attr| respond_to?(attr) }
+          require 'attr_encrypted'
 
-        unless attr_encrypted?(:otp_secret)
-          attr_encrypted :otp_secret,
-            :key  => self.otp_secret_encryption_key,
-            :mode => :per_attribute_iv_and_salt unless self.attr_encrypted?(:otp_secret)
+          unless singleton_class.ancestors.include?(AttrEncrypted)
+            extend AttrEncrypted
+          end
+
+          unless attr_encrypted?(:otp_secret)
+            attr_encrypted :otp_secret,
+              :key  => self.otp_secret_encryption_key,
+              :mode => :per_attribute_iv_and_salt unless self.attr_encrypted?(:otp_secret)
+          end
         end
 
         attr_accessor :otp_attempt


### PR DESCRIPTION
It appears that https://github.com/tinfoil/devise-two-factor/pull/13 is no longer effective in avoiding the clash of the two gems. 

This PR re-fixes the issue by not requiring `attr_encrypted` if an `otp_secret` setter and getter have already been set.