### PR TITLE
Use ROTP::Base32 for backup codes

### DIFF
--- a/lib/devise_two_factor/models/two_factor_backupable.rb
+++ b/lib/devise_two_factor/models/two_factor_backupable.rb
@@ -1,3 +1,5 @@
+require 'rotp'
+
 module Devise
   module Models
     # TwoFactorBackupable allows a user to generate backup codes which
@@ -20,7 +22,7 @@ module Devise
         code_length     = self.class.otp_backup_code_length
 
         number_of_codes.times do
-          codes << SecureRandom.hex(code_length / 2) # Hexstring has length 2*n
+          codes << ROTP::Base32.random_base32(code_length)
         end
 
         hashed_codes = codes.map { |code| Devise::Encryptor.digest(self.class, code) }

--- a/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
@@ -18,6 +18,7 @@ RSpec.shared_examples 'two_factor_backupable' do
       it 'generates recovery codes of the correct length' do
         @plaintext_codes.each do |code|
           expect(code.length).to eq(subject.class.otp_backup_code_length)
+          expect(code).to match(/\A[2-7a-z]+\z/)
         end
       end
 


### PR DESCRIPTION
This uses SecureRandom under the hood and provides more randomness per character.