### PR TITLE
Drop timecop dependency

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',      '> 3'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'faker'
-  s.add_development_dependency 'timecop'
 end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -32,12 +32,12 @@ RSpec.shared_examples 'two_factor_authenticatable' do
     let(:otp_secret) { '2z6hxkdwi3uvrnpn' }
 
     before :each do
-      Timecop.freeze(Time.current)
+      travel_to(Time.now)
       subject.otp_secret = otp_secret
     end
 
     after :each do
-      Timecop.return
+      travel_back
     end
 
     context 'with a stored consumed_timestep' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,14 +19,15 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'rspec'
 require 'faker'
-require 'timecop'
 require 'devise-two-factor'
 require 'devise_two_factor/spec_helpers'
+require 'active_support/testing/time_helpers'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
   config.order = 'random'
 end


### PR DESCRIPTION
`travel_to` is built into active support. Since devise minimal version of active support already includes this helper we can avoid extra dependency.