### PR TITLE
Fix ActiveSupport::Testing::TimeHelpers require in shared examples - Fix #188

### DIFF
--- a/lib/devise_two_factor/spec_helpers.rb
+++ b/lib/devise_two_factor/spec_helpers.rb
@@ -1,2 +1,8 @@
+require 'active_support/testing/time_helpers'
+
 require 'devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples'
 require 'devise_two_factor/spec_helpers/two_factor_backupable_shared_examples'
+
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,13 +21,11 @@ require 'rspec'
 require 'faker'
 require 'devise-two-factor'
 require 'devise_two_factor/spec_helpers'
-require 'active_support/testing/time_helpers'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  config.include ActiveSupport::Testing::TimeHelpers
   config.order = 'random'
 end


### PR DESCRIPTION
The `TimeHelpers` module seems to be needed in the shared examples but not in the gem tests.
This require/include raises an error in a Rails app that requires `'devise_two_factor/spec_helpers'` as the README recommends.