### PR TITLE
Accept whitespace in provided codes

### DIFF
--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -35,7 +35,7 @@ module Devise
         return false unless code.present? && otp_secret.present?
 
         totp = otp(otp_secret)
-        if totp.verify(code, drift_behind: self.class.otp_allowed_drift, drift_ahead: self.class.otp_allowed_drift)
+        if totp.verify(code.gsub(/\s+/, ""), drift_behind: self.class.otp_allowed_drift, drift_ahead: self.class.otp_allowed_drift)
           return consume_otp!
         end
 

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -73,6 +73,11 @@ RSpec.shared_examples 'two_factor_authenticatable' do
       expect(subject.validate_and_consume_otp!(otp)).to be true
     end
 
+    it 'validates a precisely correct OTP with whitespace' do
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now)
+      expect(subject.validate_and_consume_otp!(otp.split("").join(" "))).to be true
+    end
+
     it 'fails a nil OTP value' do
       otp = nil
       expect(subject.validate_and_consume_otp!(otp)).to be false


### PR DESCRIPTION
Many 2FA apps display a code in the format: "123 456", with a space in the middle.

Some users enter this space when logging in, which currently causes the 2FA code to be rejected. It would be nice if such codes were accepted despite the additional space.