### PR TITLE
if codes are stored as string eval() them

### DIFF
--- a/lib/devise_two_factor/models/two_factor_backupable.rb
+++ b/lib/devise_two_factor/models/two_factor_backupable.rb
@@ -33,6 +33,7 @@ module Devise
       # iff that code is a valid backup code.
       def invalidate_otp_backup_code!(code)
         codes = self.otp_backup_codes || []
+        codes = eval(codes) if codes.is_a?(String)
 
         codes.each do |backup_code|
           next unless Devise::Encryptor.compare(self.class, backup_code, code)

--- a/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_authenticatable.rb
@@ -9,6 +9,8 @@ module Devise
         # 2. The password is correct, and OTP is not required for login
         # We check the OTP, then defer to DatabaseAuthenticatable
         if validate(resource) { validate_otp(resource) }
+          resource.failed_attempts -= 1
+          resource.save!
           super
         end
 

--- a/lib/devise_two_factor/strategies/two_factor_backupable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_backupable.rb
@@ -8,6 +8,7 @@ module Devise
         if validate(resource) { resource.invalidate_otp_backup_code!(params[scope]['otp_attempt']) }
           # Devise fails to authenticate invalidated resources, but if we've
           # gotten here, the object changed (Since we deleted a recovery code)
+          resource.failed_attempts -= 1
           resource.save!
           super
         end


### PR DESCRIPTION
In my database codes are stored as text because of this migration:
`add_column :users, :otp_backup_codes, :text, array: true` from the documentation.
So i need to check if codes is string and eval() it.