### PR TITLE
Replace `attr_encrypted` with Rails 7 ActiveRecord::Encryption

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -21,9 +21,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'railties',       '< 7.1'
-  s.add_runtime_dependency 'activesupport',  '< 7.1'
-  s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
+  s.add_runtime_dependency 'rails',          '< 8'
   s.add_runtime_dependency 'devise',         '~> 4.0'
   s.add_runtime_dependency 'rotp',           '~> 6.0'
 

--- a/lib/devise-two-factor.rb
+++ b/lib/devise-two-factor.rb
@@ -16,6 +16,10 @@ module Devise
   mattr_accessor :otp_secret_encryption_key
   @@otp_secret_encryption_key = nil
 
+  # The options used to encrypt OTP secrets in the database
+  mattr_accessor :otp_secret_encryption_options
+  @@otp_secret_encryption_options = {}
+
   # The length of all generated OTP backup codes
   mattr_accessor :otp_backup_code_length
   @@otp_backup_code_length = 16

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -1,3 +1,4 @@
+
 require 'rotp'
 
 module Devise
@@ -7,25 +8,13 @@ module Devise
       include Devise::Models::DatabaseAuthenticatable
 
       included do
-        unless %i[otp_secret otp_secret=].all? { |attr| method_defined?(attr) }
-          require 'attr_encrypted'
-
-          unless singleton_class.ancestors.include?(AttrEncrypted)
-            extend AttrEncrypted
-          end
-
-          unless attr_encrypted?(:otp_secret)
-            attr_encrypted :otp_secret,
-              :key  => self.otp_secret_encryption_key,
-              :mode => :per_attribute_iv_and_salt unless self.attr_encrypted?(:otp_secret)
-          end
-        end
-
         attr_accessor :otp_attempt
+
+        encrypts :otp_secret, **two_factor_otp_secret_encrypts_options
       end
 
       def self.required_fields(klass)
-        [:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt, :consumed_timestep]
+        [:otp_secret, :consumed_timestep]
       end
 
       # This defaults to the model's otp_secret
@@ -87,10 +76,19 @@ module Devise
       module ClassMethods
         Devise::Models.config(self, :otp_secret_length,
                                     :otp_allowed_drift,
-                                    :otp_secret_encryption_key)
+                                    :otp_secret_encryption_key,
+                                    :otp_secret_encryption_options)
 
         def generate_otp_secret(otp_secret_length = self.otp_secret_length)
           ROTP::Base32.random_base32(otp_secret_length)
+        end
+
+        def two_factor_otp_secret_encrypts_options
+          if otp_secret_encryption_key.present?
+            { key: otp_secret_encryption_key }
+          else
+            otp_secret_encryption_options
+          end
         end
       end
     end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'two_factor_authenticatable' do
 
   describe 'required_fields' do
     it 'should have the attr_encrypted fields for otp_secret' do
-      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt, :consumed_timestep)
+      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:otp_secret, :consumed_timestep)
     end
   end
 
@@ -18,15 +18,7 @@ RSpec.shared_examples 'two_factor_authenticatable' do
     end
 
     it 'stores the encrypted otp_secret' do
-      expect(subject.encrypted_otp_secret).to_not be_nil
-    end
-
-    it 'stores an iv for otp_secret' do
-      expect(subject.encrypted_otp_secret_iv).to_not be_nil
-    end
-
-    it 'stores a salt for otp_secret' do
-      expect(subject.encrypted_otp_secret_salt).to_not be_nil
+      expect(subject.otp_secret).to_not be_nil
     end
   end
 

--- a/spec/devise/models/two_factor_backupable_spec.rb
+++ b/spec/devise/models/two_factor_backupable_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 require 'active_model'
 
-class TwoFactorBackupableDouble
-  extend ::ActiveModel::Callbacks
-  include ::ActiveModel::Validations::Callbacks
-  extend  ::Devise::Models
+ActiveRecord::Base.connection.create_table :two_factor_backupable_doubles, force: true do |t|
+  t.string :otp_secret
+end
+
+class TwoFactorBackupableDouble < ActiveRecord::Base
+  extend ::Devise::Models
 
   define_model_callbacks :update
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'rails'
+require 'active_record'
 require 'simplecov'
 
 module SimpleCov::Configuration
@@ -28,4 +30,22 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.filter_run_when_matching :focus
 end
+
+Rails.logger = ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
+
+ActiveRecord::Base.configurations = {
+  devise_two_factor_unit: {
+    adapter: 'sqlite3',
+    database: ':memory:'
+  }
+}
+
+ActiveRecord::Encryption.configure(
+  primary_key: 'test master key',
+  deterministic_key: 'test deterministic key',
+  key_derivation_salt: 'testing key derivation salt'
+)
+
+ActiveRecord::Base.establish_connection :devise_two_factor_unit


### PR DESCRIPTION
Creating this so everyone can discuss the feature. Things that need to be considered:

* Backwards compatibility - maybe have a major version bump and any versions from that point forward are Rails 7+ and for older Rails versions an older version of devise-two-factor should be used?
* Documentation should be updated
* A migration should perhaps be created, installable via the `rails` command, that helps to migrate existing encrypted values to the Rails 7 encryption scheme.