### PR TITLE
Allow attr_encrypted version four

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'railties',       '< 7.1'
   s.add_runtime_dependency 'activesupport',  '< 7.1'
-  s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
+  s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 5', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
   s.add_runtime_dependency 'rotp',           '~> 6.0'
 

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -64,15 +64,15 @@ describe ::Devise::Models::TwoFactorAuthenticatable do
 
     describe 'otp_secret options' do
       it 'should be of the key' do
-        expect(subject.encrypted_attributes[:otp_secret][:key]).to eq('test-key'*8)
+        expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:key]).to eq('test-key'*8)
       end
 
       it 'should be of the mode' do
-        expect(subject.encrypted_attributes[:otp_secret][:mode]).to eq(:per_attribute_iv_and_salt)
+        expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:mode]).to eq(:per_attribute_iv_and_salt)
       end
 
       it 'should be of the mode' do
-        expect(subject.encrypted_attributes[:otp_secret][:algorithm]).to eq('aes-256-cbc')
+        expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:algorithm]).to eq('aes-256-cbc')
       end
     end
   end

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -64,15 +64,31 @@ describe ::Devise::Models::TwoFactorAuthenticatable do
 
     describe 'otp_secret options' do
       it 'should be of the key' do
-        expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:key]).to eq('test-key'*8)
+        if attr_encrypted_is_rails_seven_compatible?
+          expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:key]).to eq('test-key'*8)
+        else
+          expect(subject.encrypted_attributes[:otp_secret][:key]).to eq('test-key'*8)
+        end
       end
 
       it 'should be of the mode' do
-        expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:mode]).to eq(:per_attribute_iv_and_salt)
+        if attr_encrypted_is_rails_seven_compatible?
+          expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:mode]).to eq(:per_attribute_iv_and_salt)
+        else
+          expect(subject.encrypted_attributes[:otp_secret][:mode]).to eq(:per_attribute_iv_and_salt)
+        end
       end
 
       it 'should be of the mode' do
-        expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:algorithm]).to eq('aes-256-cbc')
+        if attr_encrypted_is_rails_seven_compatible?
+          expect(subject.attr_encrypted_encrypted_attributes[:otp_secret][:algorithm]).to eq('aes-256-cbc')
+        else
+          expect(subject.encrypted_attributes[:otp_secret][:algorithm]).to eq('aes-256-cbc')
+        end
+      end
+
+      def attr_encrypted_is_rails_seven_compatible?
+        Gem::Version.new(AttrEncrypted::Version.string) >= Gem::Version.new('4.0.0')
       end
     end
   end


### PR DESCRIPTION
As of version 4.0.0, attr_encrypted supports Rails 7.

This change relaxes the version requirement for attr_encrypted so that there's a path to upgrade to Rails 7 while staying in the `devise-two-factor` 4.x series, for apps who are ready for the Rails update but not yet ready for the `devise-two-factor` 5.x update.

Relevant attr_encrypted version: https://github.com/attr-encrypted/attr_encrypted/commit/b5658765e3b7c31065e397ef5be5e6914a7e2afc
Rails 7 changes: https://github.com/attr-encrypted/attr_encrypted/pull/434

Related - https://github.com/tinfoil/devise-two-factor/issues/226

Opening this to start discussion and to kickoff the CI version matrix and see how it looks.

One thing I'm not sure about re: versioning here is how the internal method renaming that happened in attr_encrypted for Rails 7 support interacts with the gemspec requirements. I've started by changing `< 4` to `< 5` in the gemspec (presumably would bump this gem to `4.0.3`?), but possibly changing the whole line to only allow `~> 4.0` is more appropriate (and maybe bump to `4.1.0`?). Thoughts appreciated on that front ... happy to add doc changes or other version changes here as needed.