### PR TITLE
Point to Rails 8.1.0 release in appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -19,6 +19,6 @@ appraise "rails-8.0" do
 end
 
 appraise "rails-8.1" do
-  gem 'railties', '8.1.0.rc1'
-  gem 'activesupport', '8.1.0.rc1'
+  gem 'railties', '8.1.0'
+  gem 'activesupport', '8.1.0'
 end

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "railties", "8.1.0.rc1"
-gem "activesupport", "8.1.0.rc1"
+gem "railties", "8.1.0"
+gem "activesupport", "8.1.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Final release is out.

Follow up on https://github.com/devise-two-factor/devise-two-factor/pull/308 

Could probably use a version bump after this merges.

Still curious on questions from previous PR re: dropping support for older EOL'd rails/rubies versions?