### PR TITLE
Allow devise version five in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Drop support for EOL Rails versions 7.0 and 7.1
+- Remove upper limit on Devise version (allows v5) from gemspec
 
 ## 6.3.1
 

--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'railties',       '>= 7.2', '< 8.2'
   s.add_runtime_dependency 'activesupport',  '>= 7.2', '< 8.2'
-  s.add_runtime_dependency 'devise',         '>= 4.0', '< 5.0'
+  s.add_runtime_dependency 'devise',         '>= 4.0'
   s.add_runtime_dependency 'rotp',           '~> 6.0'
 
   s.add_development_dependency 'activemodel'

--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'railties',       '>= 7.2', '< 8.2'
   s.add_runtime_dependency 'activesupport',  '>= 7.2', '< 8.2'
-  s.add_runtime_dependency 'devise',         '>= 4.0'
+  s.add_runtime_dependency 'devise',         '>= 4.0', '< 6.0'
   s.add_runtime_dependency 'rotp',           '~> 6.0'
 
   s.add_development_dependency 'activemodel'


### PR DESCRIPTION
The previous change in https://github.com/devise-two-factor/devise-two-factor/pull/313 allowed the RC version to run, but final is out now and needs further relaxing. I've chosen to just remove the upper limit here ... let me know if you'd prefer `< 5.1` or something else.

I verified this works by:

- Updating limit locally, regenerating appraisal gemfiles with 5.0, running spec suite
- Updating a WIP devise update branch of a full rails app to point at my local D2F gem, running its full suite

Much of the devise release is just dropping support for EOL libs and deprecated features, and officially supporting newer rails versions, etc. I have NOT done an exhaustive review of the version diff to look specifically for interactions with devise-two-factor. Might be worth glancing at the changelog - https://github.com/heartcombo/devise/blob/main/CHANGELOG.md

Separately -- do we want to expand the appraisals and CI matrix to run suite against devise 4.x and 5.x? I guess there's some small risk here that a future devise 4.x release breaks some integration and we miss it because CI for this gem (After this change) is only running 5.x