### PR TITLE
Remove bundler-cache from Ruby setup in release job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
           ruby-version: ruby
 
       # Release


### PR DESCRIPTION
The cache can be poisoned in some edge-cases (mainly if a malicious gem were installed or a malicious action were used on any job, even if it were from the tests), so it's best to just not have the cache step here at all. It likely saves basically 0 time and it's not worth the bit of extra risk.

If the cache were poisoned in the release job specifically, that'd enable pushing a malicious version of the gem to rubygems). So just to be safe, remove the bundler cache here.

Detected with zizmor: https://docs.zizmor.sh/audits/#cache-poisoning

I'd also recommend updating the CI YML files to have explicit `permissions` defined (in both the ci _and_ push workflows), as any repository created before 2023 defaults to using github tokens with read _and_ write privileges if not specified (and if the setting in the repo settings was never updated manually), and that can be... problematic if any action you use is ever compromised.