### PR TITLE
Update email link format for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-Please report any vulnerabilities to the [Black Duck PSIRT](psirt@blackduck.com).
+Please report any vulnerabilities to the [Black Duck PSIRT](mailto:psirt@blackduck.com).


### PR DESCRIPTION
The email link was wrong before and would just direct to an invalid github URL.