### PR TITLE
✨ Allow changing the drift per call

### DIFF
--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -44,7 +44,10 @@ module Devise
           after_timestamp = self.consumed_timestep * totp.interval
         end
 
-        timestamp = totp.verify(code.gsub(/\s+/, ""), drift_behind: self.class.otp_allowed_drift, drift_ahead: self.class.otp_allowed_drift, after: after_timestamp)
+        otp_drift_behind = options[:drift_behind] || options[:allowed_drift] || self.class.otp_allowed_drift
+        otp_drift_ahead = options[:drift_ahead] || options[:allowed_drift] || self.class.otp_allowed_drift
+
+        timestamp = totp.verify(code.gsub(/\s+/, ""), drift_behind: otp_drift_behind, drift_ahead: otp_drift_ahead, after: after_timestamp)
         return consume_otp!(totp, timestamp) if timestamp
 
         false

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -54,4 +54,43 @@ describe ::Devise::Models::TwoFactorAuthenticatable do
   end
 end
 
+describe ::Devise::Models::TwoFactorAuthenticatable do
+  context 'When validate_and_consume_otp! is called with explicit drift options' do
+    subject { TwoFactorAuthenticatableDouble.new }
+    let(:otp_secret) { subject.class.generate_otp_secret }
+    let(:default_drift) { subject.class.otp_allowed_drift }
 
+    before :each do
+      travel_to(Time.now)
+      subject.otp_secret = otp_secret
+      subject.consumed_timestep = nil
+    end
+
+    after :each do
+      travel_back
+    end
+
+    it 'validates a future OTP outside the default drift when :drift_ahead is widened' do
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now + default_drift * 2)
+      expect(subject.validate_and_consume_otp!(otp, drift_ahead: default_drift * 2)).to be true
+    end
+
+    it 'does not validate a past OTP outside the default drift when only :drift_ahead is widened' do
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now - default_drift * 2)
+      expect(subject.validate_and_consume_otp!(otp, drift_ahead: default_drift * 2)).to be false
+    end
+
+    it 'widens both directions when given :allowed_drift' do
+      future_otp = ROTP::TOTP.new(otp_secret).at(Time.now + default_drift * 2)
+      expect(subject.validate_and_consume_otp!(future_otp, allowed_drift: default_drift * 2)).to be true
+    end
+
+    it 'prefers :drift_ahead over :allowed_drift when both are given' do
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now + default_drift * 2)
+      result = subject.validate_and_consume_otp!(
+        otp, drift_ahead: default_drift, allowed_drift: default_drift * 2
+      )
+      expect(result).to be false
+    end
+  end
+end


### PR DESCRIPTION
Not everyone will want to use the same OTP delivery method. Some users will want to use an authenticator app, and some might want to use email, and other will use SMS. Sometimes you want to give users that choice for themself. Unfortunately, not every method is just as quick as the others. An email delivery system could take a couple minutes, a little less for SMS carriers, while app based is instant since it doesn't have to deliver anything. This make the drift being set at the global level quite difficult to deal with when trying to support multiple otp methods. 

This change aims to fix that by letting us developers specify a drift on a case by case basis as needed. That way we don't need to like muck about with Current attributes or overriding the full `verify_and_consume_otp!` method. 